### PR TITLE
Update rcube_imap_generic.php

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -4014,6 +4014,12 @@ class rcube_imap_generic
         $start  = $prev = $messages[0];
 
         foreach ($messages as $id) {
+            if (!is_numeric($id)) {
+                $id = 0;
+            }
+            if (!is_numeric($prev)) {
+                $prev = 0;
+            }
             $incr = $id - $prev;
             if ($incr > 1) { // found a gap
                 if ($start == $prev) {


### PR DESCRIPTION
On my hosting it throws many errors in logs file:
PHP Warning:  A non-numeric value encountered in /home/kopingpl/public_html/poczta/program/lib/Roundcube/rcube_imap_generic.php on line 3987

This fast fix (I'm not PHP expert) solve problem and on my short test it works good.